### PR TITLE
Use post-create script for devcontainer Home Assistant install with retry fallback

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,13 @@
 {
   "name": "OpenWRT_control (HA dev)",
   "image": "mcr.microsoft.com/devcontainers/python:3.13",
-  "forwardPorts": [8123],
+  "forwardPorts": [
+    8123
+  ],
   "mounts": [
     "source=${localWorkspaceFolder}/config,target=/config,type=bind",
     "source=${localWorkspaceFolder}/custom_components,target=/config/custom_components,type=bind"
   ],
-  "postCreateCommand": "python -m pip install --upgrade pip && pip install homeassistant==2025.12.3 colorlog --constraint https://raw.githubusercontent.com/home-assistant/core/2025.12.3/homeassistant/package_constraints.txt",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
   "remoteUser": "vscode"
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HA_VERSION="2025.12.3"
+CONSTRAINTS_URL="https://raw.githubusercontent.com/home-assistant/core/${HA_VERSION}/homeassistant/package_constraints.txt"
+
+python -m pip install --upgrade pip
+
+echo "[devcontainer] Installing Home Assistant ${HA_VERSION} with constraints..."
+if pip install "homeassistant==${HA_VERSION}" colorlog --constraint "${CONSTRAINTS_URL}"; then
+  echo "[devcontainer] Home Assistant installed with constraints."
+else
+  echo "[devcontainer] WARNING: Constraints install failed (likely network/proxy issue with raw.githubusercontent.com)."
+  echo "[devcontainer] Retrying install without constraints..."
+  pip install "homeassistant==${HA_VERSION}" colorlog
+  echo "[devcontainer] Home Assistant installed without constraints."
+fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-HA_VERSION="2025.12.3"
+HA_VERSION="2026.3.1"
 CONSTRAINTS_URL="https://raw.githubusercontent.com/home-assistant/core/${HA_VERSION}/homeassistant/package_constraints.txt"
 
 python -m pip install --upgrade pip


### PR DESCRIPTION
### Motivation

- Make the devcontainer post-create step more robust against network/proxy issues when installing Home Assistant.
- Move complex install logic out of `devcontainer.json` for readability and maintainability.

### Description

- Replace the inline `postCreateCommand` in `.devcontainer/devcontainer.json` with a call to `bash .devcontainer/post-create.sh` and normalize `forwardPorts` formatting. 
- Add `.devcontainer/post-create.sh` which upgrades `pip`, defines `HA_VERSION` and `CONSTRAINTS_URL`, installs `homeassistant` and `colorlog` using the constraints file, and retries installation without constraints on failure. 
- Add the script with executable permissions so the devcontainer can run it during creation.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c28fa2794c83289f8ff1bcf253aef5)